### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -58,7 +58,7 @@
 					<!-- Social Icons -->
 						<ul class="icons">
               {{ range .Site.Params.social }}
-              <li><a href="{{ .link }}" class="icon fa-{{ .icon }}"><span class="label">{{ .medium }}</span></a></li>
+              <li><a href="{{ .link }}" class="icon fa-{{ .icon }}" rel="me"><span class="label">{{ .medium }}</span></a></li>
               {{ end }}
 						</ul>
 


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.